### PR TITLE
Update types to `dist/index.d.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "version": "1.7.1",
   "main": "./dist/index.js",
-  "types": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "repository": "git@github.com:helios1138/graphql-typed-client.git",
   "author": "helios1138 <revan.den@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
If `types` is based on `src/index.ts`, the project using this library will be check type with the project's tsconfig.json. As a result, unexpected type errors can occur.

<img width="1207" alt="screenshot" src="https://user-images.githubusercontent.com/20325202/65232402-0adf2f00-db0c-11e9-92a3-bcb590f930a6.png">
