### PR TITLE
Fix generated relative path on Windows

### DIFF
--- a/src/render/common/relativeImportPath.ts
+++ b/src/render/common/relativeImportPath.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
 export const relativeImportPath = (from: string, to: string) => {
-  const fromResolved = path.relative(from, to)
+  const fromResolved = path.posix.relative(from, to)
   return fromResolved[0] === '.' ? fromResolved : `./${fromResolved}`
 }


### PR DESCRIPTION
Fixes #35

Forces NodeJS to generate a POSIX-compatible relative path.