### PR TITLE
Fix generated code for type-guards

### DIFF
--- a/src/render/typeGuards/renderTypeGuards.ts
+++ b/src/render/typeGuards/renderTypeGuards.ts
@@ -3,7 +3,7 @@ import { excludedTypes } from '../common/excludedTypes'
 import { RenderContext } from '../common/RenderContext'
 
 const renderTypeGuard = (target: string, possible: string[]) => `
-  const ${target}_possibleTypes = [${possible.map(t => `'${t}'`).join(',')}]
+  const ${target}_possibleTypes: String[] = [${possible.map(t => `'${t}'`).join(',')}]
   export const is${target} = (obj: { __typename: String }): obj is ${target} => {
     if (!obj.__typename) throw new Error('__typename is missing')
     return ${target}_possibleTypes.includes(obj.__typename)


### PR DESCRIPTION
Fixes #37 

Explicitly types the helper array `{name}_possibleTypes` as `String[]`.

An alternative would be to check if the arrays are empty, and don't emit the code in that case (in lines 21 and 24).